### PR TITLE
[FEATURE] Upgrade package for Laravel 11 and Elasticsearch 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1|^8.2",
         "elasticsearch/elasticsearch": "^8.0",
-        "illuminate/contracts": "^10.0"
+        "illuminate/contracts": "^10.0 || ^11.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.1",

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         volumes:
             - ./../:/var/www/html
     mysql:
-        image: bitnami/mariadb:10.11.2
+        image: mariadb:10.11.2
         ports:
             - "3306:3306"
         volumes:

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -264,7 +264,13 @@ class Query
             $this->params['body']['aggs'] = $this->aggregations;
         }
 
-        return json_decode(resolve(Client::class)->search($this->params)->getBody(), true);
+        $result = resolve(Client::class)->search($this->params);
+
+        if (is_array($result)) {
+            return $result;
+        }
+
+        return json_decode($result->getBody(), true);
     }
 
     public function toRaw(): array


### PR DESCRIPTION
- Allow `illuminate/contracts` ^10.0 || ^11.0 for Laravel 11 support
- Update Elasticsearch query execution to handle both array responses and Response objects
- Switch MariaDB Docker image from bitnami to official mariadb:10.11.2